### PR TITLE
URL rewriting in contents

### DIFF
--- a/test/ImportCommandTest.php
+++ b/test/ImportCommandTest.php
@@ -238,6 +238,7 @@ class ImportCommandTest extends \PHPUnit_Framework_TestCase
                 '--rewrite-host' => 'http://localhost'
             ]
         );
+        $this->assertContains('Wrote <http://example.com/core/module/test>; rel="self"', $cmdTester->getDisplay());
     }
 
     /**

--- a/test/ImportCommandTest.php
+++ b/test/ImportCommandTest.php
@@ -231,7 +231,7 @@ class ImportCommandTest extends \PHPUnit_Framework_TestCase
         );
 
         $cmdTester = $this->getTester(
-            $sut, 
+            $sut,
             __DIR__ . '/fixtures/set-01/test-4.json',
             [
                 'host' => 'http://example.com',

--- a/test/fixtures/set-01/test-4.json
+++ b/test/fixtures/set-01/test-4.json
@@ -1,0 +1,4 @@
+---
+target: /core/module/test
+---
+"http://localhost/core/app/test"


### PR DESCRIPTION
Allows us to have ``http://localhost`` in the initial data files and still import them with whatever the target host is in the contents.

All this usually should do is a simple ``str_replace('http://localhost', $host)`` on the full contents of each file.