### PR TITLE
Use native php decode for loading .json files

### DIFF
--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -11,6 +11,7 @@ namespace Graviton\ImportExport\Command;
 
 use Graviton\ImportExport\Exception\MissingTargetException;
 use Graviton\ImportExport\Exception\JsonParseException;
+use Graviton\ImportExport\Exception\UnknownFileTypeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -267,6 +268,8 @@ class ImportCommand extends Command
             }
         } elseif (substr($file, -4) == '.yml') {
             $data = $this->parser->parse($content, false, false, true);
+        } else {
+            throw new UnknownFileTypeException($file);
         }
 
         return $data;

--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -198,13 +198,11 @@ class ImportCommand extends Command
     {
         $content = str_replace($rewriteHost, $host, $doc->getContent());
 
-        $data = $this->parseContent($content, $file);
-
         $promise = $this->client->requestAsync(
             'PUT',
             $targetUrl,
             [
-                'json' => $data,
+                'json' => $this->parseContent($content, $file),
             ]
         );
         $promise->then(

--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -256,7 +256,7 @@ class ImportCommand extends Command
     {
         if (substr($file, -5) == '.json') {
             $data = json_decode($content);
-            if (json_last_error() !== JSON_ERROR_NONE) { 
+            if (json_last_error() !== JSON_ERROR_NONE) {
                 throw new JsonParseException(
                     sprintf(
                         '%s in %s',
@@ -265,7 +265,7 @@ class ImportCommand extends Command
                     )
                 );
             }
-        } else if (substr($file, -4) == '.yml') {
+        } elseif (substr($file, -4) == '.yml') {
             $data = $this->parser->parse($content, false, false, true);
         }
 

--- a/src/Exception/JsonParseException.php
+++ b/src/Exception/JsonParseException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * thrown when we get a json error
+ */
+
+namespace Graviton\ImportExport\Exception;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/import-export/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class JsonParseException extends \Exception
+{
+}

--- a/src/Exception/UnknownFileTypeException.php
+++ b/src/Exception/UnknownFileTypeException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * thrown when we get a json error
+ */
+
+namespace Graviton\ImportExport\Exception;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/import-export/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class UnknownFileTypeException extends \Exception
+{
+}


### PR DESCRIPTION
~~Also starts silently ignoring files with neither ``.yml`` or ``.json`` ending (like ``*.swp`` or ``*~``)...~~ Throws a UnknownFileTypeException on file that are neither yml nor json.