### PR TITLE
Allow deleting of values for a given recordOrigin with the purge command

### DIFF
--- a/src/Command/CorePurgeCommand.php
+++ b/src/Command/CorePurgeCommand.php
@@ -91,47 +91,46 @@ class CorePurgeCommand extends Command
             throw new \LogicException('You must pass "yes" as parameter to show that you know what you\'re doing');
         }
 
-        if ($recordOrigin === null) {
-            $this->purgeCollections($input, $output);
-        } else {
-            $this->purgeResourcesByOrigin($input, $output, $recordOrigin);
+        foreach ($this->getClient($input)->{$this->databaseName}->listCollections() as $collection) {
+            if ($recordOrigin === null) {
+                $this->purgeCollection($output, $collection);
+            } else {
+                $this->purgeResourcesByOrigin($output, $recordOrigin, $collection);
+            }
         }
+
     }
 
     /**
      * purge all connections from a database
      *
-     * @param InputInterface  $input  User input on console
-     * @param OutputInterface $output Output of the command
+     * @param OutputInterface  $output     Output of the command
+     * @param \MongoCollection $collection Collection to purge
      *
      * @return void
      */
-    private function purgeCollections(InputInterface $input, OutputInterface $output)
+    private function purgeCollection(OutputInterface $output, \MongoCollection $collection)
     {
-        foreach ($this->getClient($input)->{$this->databaseName}->listCollections() as $collection) {
-            $collectionName = $collection->getName();
-            $output->writeln("<info>Dropping collection <${collectionName}></info>");
-            $collection->drop();
-        }
+        $collectionName = $collection->getName();
+        $output->writeln("<info>Dropping collection <${collectionName}></info>");
+        $collection->drop();
     }
 
     /**
      * purge all connections from a database
      *
-     * @param InputInterface  $input  User input on console
-     * @param OutputInterface $output Output of the command
-     * @param string          $origin Value of recordOrigin field to purge
+     * @param OutputInterface  $output     Output of the command
+     * @param \MongoCollection $collection Collection to purge
+     * @param string           $origin     Value of recordOrigin field to purge
      *
      * @return void
      */
-    private function purgeResourcesByOrigin(InputInterface $input, OutputInterface $output, $origin)
+    private function purgeResourcesByOrigin(OutputInterface $output, \MongoCollection $collection, $origin)
     {
-        foreach ($this->getClient($input)->{$this->databaseName}->listCollections() as $collection) {
-            $collectionName = $collection->getName();
-            $output->writeln(
-                "<info>Dropping resources with recordOrigin <${origin}> from collection <${collectionName}></info>"
-            );
-            $collection->remove(['recordOrigin' => $origin]);
-        }
+        $collectionName = $collection->getName();
+        $output->writeln(
+            "<info>Dropping resources with recordOrigin <${origin}> from collection <${collectionName}></info>"
+        );
+        $collection->remove(['recordOrigin' => $origin]);
     }
 }


### PR DESCRIPTION
This will allow us to remove all the resources with recordOrigin == core. Using this we have the possibility to remove stuff from core data in the internal initialdata repo andactually have them removed in our -pub envs automagically.

With this change we will still need to kill stuff from initialdata manually, but we wont need to manually apply stuff when we work on coredata.

I expect a thorough review of this process to take place when we reconfigure our deploy to call this. Right now merging this will not change anything except supplementing our own local dev tools.