### PR TITLE
File delete on Exists and Exit message for Jenkins

### DIFF
--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -294,6 +294,7 @@ class ImportCommand extends ImportCommandAbstract
         );
 
         // If there is a file to be uploaded, and it exists in remote, we delete it first.
+        // TODO This part, $uploadFile, promise should be removed once Graviton/File service is resolved in new Story. 
         $fileRepeatFunc = false;
         if ($uploadFile) {
             $fileRepeatFunc = function () use ($targetUrl, $successFunc, $errFunc, $output, $file, $data) {

--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -294,7 +294,7 @@ class ImportCommand extends ImportCommandAbstract
         );
 
         // If there is a file to be uploaded, and it exists in remote, we delete it first.
-        // TODO This part, $uploadFile, promise should be removed once Graviton/File service is resolved in new Story. 
+        // TODO This part, $uploadFile, promise should be removed once Graviton/File service is resolved in new Story.
         $fileRepeatFunc = false;
         if ($uploadFile) {
             $fileRepeatFunc = function () use ($targetUrl, $successFunc, $errFunc, $output, $file, $data) {


### PR DESCRIPTION
This fixes the error from a uploaded file on PUT if file already exists. It delete it and upload again. 
Errors are counted and if so exit status is set so Jenkins should do a "failed" status if errors.