### PR TITLE
Fix error handling

### DIFF
--- a/src/Command/CoreImportCommand.php
+++ b/src/Command/CoreImportCommand.php
@@ -90,10 +90,11 @@ class CoreImportCommand extends ImportCommandAbstract
      * @param InputInterface  $input  User input on console
      * @param OutputInterface $output Output of the command
      *
-     * @return void
+     * @return integer
      */
     protected function doImport(Finder $finder, InputInterface $input, OutputInterface $output)
     {
+        $exitCode = 0;
         foreach ($finder as $file) {
             $this->importResource($file, $input, $output);
         }
@@ -103,7 +104,9 @@ class CoreImportCommand extends ImportCommandAbstract
             foreach ($this->errorStack as $errorMessage) {
                 $output->writeln($errorMessage);
             }
+            $exitCode = 1;
         }
+        return $exitCode;
     }
 
     /**

--- a/src/Command/CoreImportCommand.php
+++ b/src/Command/CoreImportCommand.php
@@ -116,7 +116,7 @@ class CoreImportCommand extends ImportCommandAbstract
      * @param InputInterface  $input  User input on console
      * @param OutputInterface $output Output of the command
      *
-     * @return void
+     * @return integer
      */
     private function importResource(\SplFileInfo $file, InputInterface $input, OutputInterface $output)
     {
@@ -124,7 +124,9 @@ class CoreImportCommand extends ImportCommandAbstract
         $origDoc = $this->serializer->unserialize($doc->getContent());
 
         if (is_null($origDoc)) {
-            $output->writeln("<error>Could not deserialize file <${file}></error>");
+            $errorMessage = "<error>Could not deserialize file <${file}></error>";
+            $output->writeln($errorMessage);
+            array_push($this->errorStack, $errorMessage);
         } else {
             try {
                 $collectionName = $doc->getData()['collection'];

--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -146,6 +146,7 @@ class ImportCommand extends ImportCommandAbstract
      */
     protected function doImport(Finder $finder, InputInterface $input, OutputInterface $output)
     {
+        $exitCode = 0;
         $host = $input->getArgument('host');
         $rewriteHost = $input->getOption('rewrite-host');
         $rewriteTo = $input->getOption('rewrite-to');
@@ -160,17 +161,15 @@ class ImportCommand extends ImportCommandAbstract
         if (empty($this->errors)) {
             // No errors
             $output->writeln("\n".'<info>No errors</info>');
-            $output->writeln('0');
-            exit(0);
         } else {
             // Yes, there was errors
             $output->writeln("\n".'<info>There was errors: '.count($this->errors).'</info>');
             foreach ($this->errors as $file => $error) {
                 $output->writeln("<error>{$file}: {$error}</error>");
             }
-            $output->writeln('1');
-            exit(1);
+            $exitCode = 1;
         }
+        return $exitCode;
     }
 
     /**

--- a/src/Command/ImportCommandAbstract.php
+++ b/src/Command/ImportCommandAbstract.php
@@ -41,7 +41,7 @@ abstract class ImportCommandAbstract extends Command
      * @param InputInterface  $input  User input on console
      * @param OutputInterface $output Output of the command
      *
-     * @return void
+     * @return integer
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -68,12 +68,14 @@ abstract class ImportCommandAbstract extends Command
         }
 
         $finder->ignoreDotFiles(true)->filter($filter);
-        
+
+        $exitCode = 1;
         try {
-            $this->doImport($finder, $input, $output);
+            $exitCode = $this->doImport($finder, $input, $output);
         } catch (MissingTargetException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
         }
+        return $exitCode;
     }
 
     /**

--- a/test/Command/CoreImportCommandTest.php
+++ b/test/Command/CoreImportCommandTest.php
@@ -115,5 +115,6 @@ class CoreImportCommandTest extends \PHPUnit_Framework_TestCase
             'Could not deserialize file <' . $this->sourceDir . '/Dudess/Invalid.json>',
             $this->cmdTester->getDisplay()
         );
+        $this->assertEquals(1, $this->cmdTester->getStatusCode());
     }
 }

--- a/test/Command/ImportCommandTest.php
+++ b/test/Command/ImportCommandTest.php
@@ -76,6 +76,7 @@ class ImportCommandTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains('Loading data from ' . $file, $cmdTester->getDisplay());
         $this->assertContains('Wrote <' . $host . $path . '>; rel="self"', $cmdTester->getDisplay());
+        $this->assertEquals(0, $cmdTester->getStatusCode());
     }
 
     /**
@@ -167,6 +168,7 @@ class ImportCommandTest extends \PHPUnit_Framework_TestCase
                 $cmdTester->getDisplay()
             );
         }
+        $this->assertEquals(1, $cmdTester->getStatusCode());
     }
 
     /**
@@ -254,6 +256,7 @@ class ImportCommandTest extends \PHPUnit_Framework_TestCase
             ]
         );
         $this->assertContains('Wrote <http://example.com/core/module/test>; rel="self"', $cmdTester->getDisplay());
+        $this->assertEquals(0, $cmdTester->getStatusCode());
     }
 
     /**


### PR DESCRIPTION
Twas badly broken due to excessive `exit()` use and a dire lack of manual reading and testing.